### PR TITLE
Teradata: add LOCKING syntax support

### DIFF
--- a/test/fixtures/dialects/teradata/locking.sql
+++ b/test/fixtures/dialects/teradata/locking.sql
@@ -1,0 +1,8 @@
+LOCKING DATABASE database_name FOR ACCESS
+SELECT a FROM database.mytable;
+
+LOCKING TABLE table_name FOR READ
+SELECT a FROM table_name;
+
+LOCK ROW FOR WRITE
+SELECT a FROM table_name;

--- a/test/fixtures/dialects/teradata/locking.yml
+++ b/test/fixtures/dialects/teradata/locking.yml
@@ -1,0 +1,73 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1ad87a8bfbb40aa8631540e7ae69cb2ac3573901eb5567bd5aba414c798ed721
+file:
+- statement:
+    select_statement:
+      locking_clause:
+      - keyword: LOCKING
+      - keyword: DATABASE
+      - object_reference:
+          naked_identifier: database_name
+      - keyword: FOR
+      - keyword: ACCESS
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: database
+              - dot: .
+              - naked_identifier: mytable
+- statement_terminator: ;
+- statement:
+    select_statement:
+      locking_clause:
+      - keyword: LOCKING
+      - keyword: TABLE
+      - object_reference:
+          naked_identifier: table_name
+      - keyword: FOR
+      - keyword: READ
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    select_statement:
+      locking_clause:
+      - keyword: LOCK
+      - keyword: ROW
+      - keyword: FOR
+      - keyword: WRITE
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Teradata supports LOCKING databases and tables before a select statement ([documentation](https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Manipulation-Language/Statement-Syntax/LOCKING-Request-Modifier/LOCKING-Request-Modifier-Syntax))
This PR adds support for this new statement, and integrates it in the select statement derived from ansi.


### Are there any other side effects of this change that we should be aware of?
None that I can think of.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
- Added appropriate documentation for the change.
